### PR TITLE
link fix

### DIFF
--- a/docs/using_katana/ondemand.md
+++ b/docs/using_katana/ondemand.md
@@ -2,7 +2,7 @@ title: Katana OnDemand
 
 There are a number of GUI based software packages that are offered through a web interface. The requirements are a Katana account and for the user to be either on campus or connected to the [UNSW VPN](https://vpn.unsw.edu.au).
 
-These can be accessed from https://kod.restech.unsw.edu.au
+These can be accessed from [https://kod.restech.unsw.edu.au](https://kod.restech.unsw.edu.au)
 
 After logging in, you can:
 


### PR DESCRIPTION
Attempted to make the link clickable at https://docs.restech.unsw.edu.au/using_katana/ondemand/ - note it is already clickable in GitHub's own previewer, but not on the docs page. Hope specifying it as a link manually will fix this.